### PR TITLE
CTL-994 Fixed DesignPersonViewModel so it can be used to populate PersonWindow class with sample data at design-time

### DIFF
--- a/src/NET/Catel.Examples.WPF.PersonApplication/ViewModels/PersonViewModel.cs
+++ b/src/NET/Catel.Examples.WPF.PersonApplication/ViewModels/PersonViewModel.cs
@@ -20,8 +20,9 @@
         /// <param name="person">The person.</param>
         public PersonViewModel(Person person)
         {
+            if (Catel.CatelEnvironment.IsInDesignMode)
+                return; // This prevents constructor code from being executed at design-time
             Person = person ?? new Person();
-
             GenerateData = new Command<object, object>(OnGenerateDataExecute, OnGenerateDataCanExecute);
             ToggleCustomError = new Command<object>(OnToggleCustomErrorExecute);
         }
@@ -237,8 +238,12 @@
         /// Initializes a new instance of the <see cref="DesignPersonViewModel"/> class.
         /// </summary>
         public DesignPersonViewModel()
-            : base(new Person { FirstName = "Geert", MiddleName = "van", LastName = "Horrik", Gender = Gender.Male })
+            : base(null)
         {
+            SetValue("FirstName", "Geert");
+            SetValue("MiddleName", "van");
+            SetValue("LastName", "Horrik");
+            Gender = Gender.Male;
         }
     }
 }

--- a/src/NET/Catel.Examples.WPF.PersonApplication/ViewModels/PersonViewModel.cs
+++ b/src/NET/Catel.Examples.WPF.PersonApplication/ViewModels/PersonViewModel.cs
@@ -45,7 +45,6 @@
         [Model]
         [Fody.Expose("FirstName")]
         [Fody.Expose("MiddleName")]
-        [Fody.Expose("LastName")]
         public Person Person
         {
             get { return GetValue<Person>(PersonProperty); }
@@ -104,20 +103,20 @@
         ///// </summary>
         //public static readonly PropertyData MiddleNameProperty = RegisterProperty("MiddleName", typeof(string));
 
-        ///// <summary>
-        ///// Gets or sets the last name.
-        ///// </summary>
-        //[ViewModelToModel("Person")]
-        //public string LastName
-        //{
-        //    get { return GetValue<string>(LastNameProperty); }
-        //    set { SetValue(LastNameProperty, value); }
-        //}
+        /// <summary>
+        /// Gets or sets the last name.
+        /// </summary>
+        [ViewModelToModel("Person")]
+        public string LastName
+        {
+            get { return GetValue<string>(LastNameProperty); }
+            set { SetValue(LastNameProperty, value); }
+        }
 
-        ///// <summary>
-        ///// Register the LastName property so it is known in the class.
-        ///// </summary>
-        //public static readonly PropertyData LastNameProperty = RegisterProperty("LastName", typeof(string));
+        /// <summary>
+        /// Register the LastName property so it is known in the class.
+        /// </summary>
+        public static readonly PropertyData LastNameProperty = RegisterProperty("LastName", typeof(string));
 
         /// <summary>
         /// Gets or sets the custom error.
@@ -166,7 +165,7 @@
                 return false;
             }
 
-            if (!string.IsNullOrEmpty(GetValue<string>("LastName")))
+            if (!string.IsNullOrEmpty(this.LastName))
             {
                 return false;
             }
@@ -182,8 +181,8 @@
         {
             Gender = Gender.Male;
             SetValue("FirstName", "John");
-            SetValue("MiddleName", "");
-            SetValue("LastName", "Doe");
+            SetValue("MiddleName", "Mathew");
+            LastName = "Smith";
         }
 
         /// <summary>
@@ -240,9 +239,12 @@
         public DesignPersonViewModel()
             : base(null)
         {
+            // Direct manipulation on viewmodel's property bag. This a requirement if you intend to use Fody.Expose decorator
             SetValue("FirstName", "Geert");
             SetValue("MiddleName", "van");
-            SetValue("LastName", "Horrik");
+
+            // Regular sample usage
+            LastName = "Horrik";
             Gender = Gender.Male;
         }
     }


### PR DESCRIPTION
Changes proposed in this pull request:
- CTL-994 Fixed DesignPersonViewModel so it can be used to populate PersonWindow class with sample data at design-time.
- Regarding to current master branch,did some balance adjustment on PersonViewModel between Fody.Exposed properties and regular dependency properties. In short, FirstName and MiddleName are still using Fody.Expose, LastName became a regular dependency property along with Genre. This way the sample code provides both flavours easing the decision on learning 